### PR TITLE
Conserta markup e adiciona comunidades

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@ Esse repositório destina-se a listar todas as comunidades de Python da América
 
 PS.: Caso você queira contribuir com alguma comunidade que não encontra-se na lista ou alterar alguma, por favor envie a correção.
 
-Por favor ao incluir as comunidades coloque na ordem alfabética de estados e se possível links com site, facebook , twitter da comunidade. ( No caso de Django Girls, se possível não coloque o site pois ele fica inativo após o evento, coloque o Facebook ou Twitter)
+Por favor ao incluir as comunidades coloque na ordem alfabética de estados e se possível links com site, facebook, twitter da comunidade. (No caso de Django Girls, se possível não coloque o site pois ele fica inativo após o evento, coloque o Facebook ou Twitter)
 
 --------------------------------------------------
 Repository of Python Communities in Latin America
 ==================================================
 The repository is intended to list all Latin American communities Python, separated by countries and states.
 
-PS .: If you want to contribute to a community that is not on the list or change any, please send the patch.
+PS.: If you want to contribute to a community that is not on the list or change any, please send the patch.
 
-Please include the communities put in alphabetical order of states and possible links with site, facebook, twitter community.(In the case of Django Girls, if possible do not put the site as it becomes inactive after the event, place the Facebook or Twitter)
+Please include the communities put in alphabetical order of states and possible links with website, facebook, twitter community. (In the case of Django Girls, if possible do not put the site as it becomes inactive after the event, place the Facebook or Twitter)
 
 -------------------------------------------------------
 Repositorio de Comunidades de Python en América Latina
 =======================================================
 El repositorio es enumerar todas las comunidades de América Latina Python, separadas por países y estados.
 
-PD:. Si quieres contribuir a una comunidad que no está en la lista o cambiar cualquiera, por favor enviar el parche.
+PD.: Si quieres contribuir a una comunidad que no está en la lista o cambiar cualquiera, por favor enviar el parche.
 
-Por favor, incluya las comunidades puestas en orden alfabético de los estados y posibles vínculos con el sitio, facebook, gorjeo comunidad.(En el caso de Django niñas, si es posible, no ponga el sitio, ya que se inactiva después del evento, coloque el Facebook o Twitter)
+Por favor, incluya las comunidades puestas en orden alfabético de los estados y posibles vínculos con el sitio, facebook, gorjeo comunidad. (En el caso de Django niñas, si es posible, no ponga el sitio, ya que se inactiva después del evento, coloque el Facebook o Twitter)

--- a/comunidades/Argentina.md
+++ b/comunidades/Argentina.md
@@ -1,28 +1,28 @@
 Las comunidades en Argentina
 
-###Argentina
+### Argentina
 
 Comunidad | Sitio Web 
- --- | --- 
-- PyAr | [http://www.python.org.ar/](http://www.python.org.ar/)
+ --- | ---
+ PyAr | [http://www.python.org.ar/](http://www.python.org.ar/)
 
 
-###Buenos Aires
+### Buenos Aires
 
-Comunidad | Sitio Web 
- --- | --- 
-
-
-###Mendoza
-
-Comunidad | Sitio Web 
- --- | --- 
- - Django Girls Mendoza | [https://www.facebook.com/djangogirlsmdz/](https://www.facebook.com/djangogirlsmdz/)
- - Pyladies Mendoza | [https://pkpacheco.github.io/pyladies-mendoza/](https://pkpacheco.github.io/pyladies-mendoza/)
+Comunidad | Sitio Web
+ --- | ---
 
 
-###Patagonia
+### Mendoza
+
+Comunidad | Sitio Web
+ --- | ---
+ Django Girls Mendoza | [https://www.facebook.com/djangogirlsmdz/](https://www.facebook.com/djangogirlsmdz/)
+ Pyladies Mendoza | [https://pkpacheco.github.io/pyladies-mendoza/](https://pkpacheco.github.io/pyladies-mendoza/)
+
+
+### Patagonia
 
 Comunidad | Sitio Web
 --- | ---
-  - Meetup Patagónico de Python | [https://www.meetup.com/es-ES/Patagonia-Python-Meetup](https://www.meetup.com/es-ES/Patagonia-Python-Meetup)
+Meetup Patagónico de Python | [https://www.meetup.com/es-ES/Patagonia-Python-Meetup](https://www.meetup.com/es-ES/Patagonia-Python-Meetup)

--- a/comunidades/Bolivia.md
+++ b/comunidades/Bolivia.md
@@ -1,12 +1,12 @@
 Las comunidades en Bolivia
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
-###Rio de Janeiro(ejemplo)
+### Rio de Janeiro(ejemplo)
 
 Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/)
 
 -->

--- a/comunidades/Brazil.md
+++ b/comunidades/Brazil.md
@@ -1,8 +1,14 @@
 Comunidades no Brasil
 
+## Brasil
+Comunidade | Site
+ --- | ---
+PyLadies Brasil | [http://brasil.pyladies.com/](http://brasil.pyladies.com/)
+Python Brasil | [https://www.facebook.com/pythonbrasil/](https://www.facebook.com/pythonbrasil/)
+
 ## Sudeste
 
-###Rio de Janeiro
+### Rio de Janeiro
 Comunidade | Site
  --- | ---
 PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/)
@@ -15,6 +21,8 @@ PythOnRio | [https://www.facebook.com/pythonrio](https://www.facebook.com/python
 Comunidade | Site
  --- | ---
 PyLadies Belo Horizonte | [https://www.facebook.com/pyladiesbh](https://www.facebook.com/pyladiesbh)
+Belo Horizonte Python User Group | [https://www.meetup.com/Belo-Horizonte-Python-User-Group/](https://www.meetup.com/Belo-Horizonte-Python-User-Group/)
+PyData Belo Horizonte | [https://www.meetup.com/PyData-Belo-Horizonte/](https://www.meetup.com/PyData-Belo-Horizonte/)
 
 ### São Paulo
 Comunidade | Site
@@ -29,6 +37,7 @@ grupy-rp | [http://grupyrp.github.io/](http://grupyrp.github.io/)
 grupy-sanca | [https://www.facebook.com/grupysanca/](https://www.facebook.com/grupysanca/)
 grupy-sp | [http://www.meetup.com/grupy-sp](http://www.meetup.com/grupy-sp)
 
+
 ## Norte
 
 ## Nordeste
@@ -36,7 +45,6 @@ grupy-sp | [http://www.meetup.com/grupy-sp](http://www.meetup.com/grupy-sp)
 ### Rio Grande do Norte
 Comunidade | Site
  --- | ---
-PyLadies Brasil | [http://brasil.pyladies.com/](http://brasil.pyladies.com/)
 PyLadies Natal | [https://www.facebook.com/PyLadiesNatal/](https://www.facebook.com/PyLadiesNatal/)
 
 ### Pernambuco

--- a/comunidades/Brazil.md
+++ b/comunidades/Brazil.md
@@ -3,87 +3,86 @@ Comunidades no Brasil
 ## Sudeste
 
 ###Rio de Janeiro
-Comunidade | Site 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/)
-- PyLadies Duque de Caxias | [http://duquedecaxias.pyladies.com/](http://duquedecaxias.pyladies.com/)
-- Django Girls Rio de Janeiro | [https://www.facebook.com/djangogirlsrio](https://www.facebook.com/djangogirlsrio)
-- PythOnRio | [https://www.facebook.com/pythonrio](https://www.facebook.com/pythonrio)
+Comunidade | Site
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/)
+PyLadies Duque de Caxias | [http://duquedecaxias.pyladies.com/](http://duquedecaxias.pyladies.com/)
+Django Girls Rio de Janeiro | [https://www.facebook.com/djangogirlsrio](https://www.facebook.com/djangogirlsrio)
+PythOnRio | [https://www.facebook.com/pythonrio](https://www.facebook.com/pythonrio)
 
 
 ### Minas Gerais
-Comunidade | Site 
- --- | --- 
-- PyLadies Belo Horizonte | [https://www.facebook.com/pyladiesbh](https://www.facebook.com/pyladiesbh)
+Comunidade | Site
+ --- | ---
+PyLadies Belo Horizonte | [https://www.facebook.com/pyladiesbh](https://www.facebook.com/pyladiesbh)
 
 ### São Paulo
-Comunidade | Site 
- --- | --- 
-- PyLadies São Paulo | [http://www.meetup.com/pt-BR/PyLadiesSP/](http://www.meetup.com/pt-BR/PyLadiesSP/)
-- PyLadies Campinas | [https://www.facebook.com/pyladiescps](https://www.facebook.com/pyladiescps)
-- PyLadies São Carlos | [https://www.facebook.com/PyLadiesSaoCarlos](https://www.facebook.com/PyLadiesSaoCarlos)
-- PyLadies Vale | [http://vale.pyladies.com/](http://vale.pyladies.com/)
-- Django Girls São José dos Campos | [https://www.facebook.com/djangogirlssjc](https://www.facebook.com/djangogirlssjc)
-- Pyladies Vale | [http://vale.pyladies.com/](http://vale.pyladies.com/)
-- grupy-rp | [http://grupyrp.github.io/](http://grupyrp.github.io/)
-- grupy-sanca | [https://www.facebook.com/grupysanca/](https://www.facebook.com/grupysanca/)
-- grupy-sp | [http://www.meetup.com/grupy-sp](http://www.meetup.com/grupy-sp)
-
+Comunidade | Site
+ --- | ---
+PyLadies São Paulo | [http://www.meetup.com/pt-BR/PyLadiesSP/](http://www.meetup.com/pt-BR/PyLadiesSP/)
+PyLadies Campinas | [https://www.facebook.com/pyladiescps](https://www.facebook.com/pyladiescps)
+PyLadies São Carlos | [https://www.facebook.com/PyLadiesSaoCarlos](https://www.facebook.com/PyLadiesSaoCarlos)
+PyLadies Vale | [http://vale.pyladies.com/](http://vale.pyladies.com/)
+Django Girls São José dos Campos | [https://www.facebook.com/djangogirlssjc](https://www.facebook.com/djangogirlssjc)
+Pyladies Vale | [http://vale.pyladies.com/](http://vale.pyladies.com/)
+grupy-rp | [http://grupyrp.github.io/](http://grupyrp.github.io/)
+grupy-sanca | [https://www.facebook.com/grupysanca/](https://www.facebook.com/grupysanca/)
+grupy-sp | [http://www.meetup.com/grupy-sp](http://www.meetup.com/grupy-sp)
 
 ## Norte
 
 ## Nordeste
 
-### Natal
-Comunidade | Site 
- --- | --- 
-- PyLadies Brasil | [http://brasil.pyladies.com/](http://brasil.pyladies.com/)
-- PyLadies Natal | [https://www.facebook.com/PyLadiesNatal/](https://www.facebook.com/PyLadiesNatal/)
+### Rio Grande do Norte
+Comunidade | Site
+ --- | ---
+PyLadies Brasil | [http://brasil.pyladies.com/](http://brasil.pyladies.com/)
+PyLadies Natal | [https://www.facebook.com/PyLadiesNatal/](https://www.facebook.com/PyLadiesNatal/)
 
 ### Pernambuco
-Comunidade | Site 
- --- | --- 
-- PyLadies Recife | [https://www.facebook.com/pyladiesrecife/](https://www.facebook.com/pyladiesrecife/)
+Comunidade | Site
+ --- | ---
+PyLadies Recife | [https://www.facebook.com/pyladiesrecife/](https://www.facebook.com/pyladiesrecife/)
 
 ### Ceará
-Comunidade | Site 
- --- | --- 
-- PyLadies Fortaleza | [https://www.facebook.com/PyLadiesFortaleza](https://www.facebook.com/PyLadiesFortaleza)
-- PUG-CE | [http://pugce.org/](http://pugce.org/)
+Comunidade | Site
+ --- | ---
+PyLadies Fortaleza | [https://www.facebook.com/PyLadiesFortaleza](https://www.facebook.com/PyLadiesFortaleza)
+PUG-CE | [http://pugce.org/](http://pugce.org/)
 
 ### Bahia
-Comunidade | Site 
- --- | --- 
-- PyLadies Salvador | [https://www.facebook.com/PyLadiesSalvador](https://www.facebook.com/PyLadiesSalvador)
- 
+Comunidade | Site
+ --- | ---
+PyLadies Salvador | [https://www.facebook.com/PyLadiesSalvador](https://www.facebook.com/PyLadiesSalvador)
+
 ### Sergipe
-Comunidade | Site 
- --- | --- 
-- PUG-SE | [http://pug-se.github.io/](http://pug-se.github.io/)
+Comunidade | Site
+ --- | ---
+PUG-SE | [http://pug-se.github.io/](http://pug-se.github.io/)
 
 ## Centro-Oeste
 
 ### Distrito Federal
-Comunidade | Site 
- --- | --- 
-- PyLadies Brasília | []()
-- Grupy-DF | [http://df.python.org.br](http://df.python.org.br)
+Comunidade | Site
+ --- | ---
+PyLadies Brasília | []()
+Grupy-DF | [http://df.python.org.br](http://df.python.org.br)
 
 ## Sul
 
 ### Santa Catarina
-Comunidade | Site 
- --- | --- 
-- Python Floripa | [http://floripa.sc.python.org.br](http://floripa.sc.python.org.br)
-- Django Girls Florianópolis | [https://www.facebook.com/DGFloripa](https://www.facebook.com/DGFloripa)
+Comunidade | Site
+ --- | ---
+Python Floripa | [http://floripa.sc.python.org.br](http://floripa.sc.python.org.br)
+Django Girls Florianópolis | [https://www.facebook.com/DGFloripa](https://www.facebook.com/DGFloripa)
 
 ### Paraná
-Comunidade | Site 
- --- | --- 
-- PyLadies Curitiba | [http://www.meetup.com/pt-BR/PyLadies-Curitiba/](http://www.meetup.com/pt-BR/PyLadies-Curitiba/)
+Comunidade | Site
+ --- | ---
+PyLadies Curitiba | [http://www.meetup.com/pt-BR/PyLadies-Curitiba/](http://www.meetup.com/pt-BR/PyLadies-Curitiba/)
 
 ### Rio Grande do Sul
-Comunidade | Site 
- --- | --- 
-- PyLadies Porto Alegre | [https://pyladiespoa.pythonanywhere.com/](https://pyladiespoa.pythonanywhere.com/)
-- PyTchê | [https://www.facebook.com/PyTche/](https://www.facebook.com/PyTche/)
+Comunidade | Site
+ --- | ---
+PyLadies Porto Alegre | [https://pyladiespoa.pythonanywhere.com/](https://pyladiespoa.pythonanywhere.com/)
+PyTchê | [https://www.facebook.com/PyTche/](https://www.facebook.com/PyTche/)

--- a/comunidades/Chile.md
+++ b/comunidades/Chile.md
@@ -1,19 +1,12 @@
 Las comunidades en Chile
 
-
-###Santiago
-
-Comunidad | Sitio Web 
- --- | --- 
-
-
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/)
 
 -->

--- a/comunidades/Colombia.md
+++ b/comunidades/Colombia.md
@@ -1,51 +1,51 @@
 Las comunidades en Colombia
 
-###Colombia
+### Colombia
 
-Comunidad | Sitio Web 
- --- | --- 
-- Python Colombia | [http://www.python-colombia.org/](http://www.python-colombia.org/)
-
-
-###Medellín
-
-Comunidad | Sitio Web 
- --- | --- 
- - Python Medellín | [http://www.meetup.com/es/Medellin-Python-y-Django-Meetup/] (http://www.meetup.com/es/Medellin-Python-y-Django-Meetup/)
- - Pyladies Medellín | [http://www.meetup.com/es/Python-Ladies-Medellin/](http://www.meetup.com/es/Python-Ladies-Medellin/)
+Comunidad | Sitio Web
+ --- | ---
+Python Colombia | [http://www.python-colombia.org/](http://www.python-colombia.org/)
 
 
-###Barranquilla
+### Medellín
 
-Comunidad | Sitio Web 
- --- | --- 
-- Django Barranquilla | [http://www.meetup.com/es/Django-Barranquilla/](http://www.meetup.com/es/Django-Barranquilla/)
-
-
-###Bogotá
-
-Comunidad | Sitio Web 
- --- | --- 
-- Bogotá Python | [http://www.meetup.com/es/pythoncolombia-bogota/](http://www.meetup.com/es/pythoncolombia-bogota/)
-- Django Bogotá | [http://www.meetup.com/es/Django-Bogota/](http://www.meetup.com/es/Django-Bogota/)
+Comunidad | Sitio Web
+ --- | ---
+ Python Medellín | [http://www.meetup.com/es/Medellin-Python-y-Django-Meetup/] (http://www.meetup.com/es/Medellin-Python-y-Django-Meetup/)
+ Pyladies Medellín | [http://www.meetup.com/es/Python-Ladies-Medellin/](http://www.meetup.com/es/Python-Ladies-Medellin/)
 
 
-###Cali
+### Barranquilla
 
-Comunidad | Sitio Web 
- --- | --- 
- - Django Cali  | [https://www.facebook.com/djangocalico/](https://www.facebook.com/djangocalico/)
-
-
-###Santa Marta
-
-Comunidad | Sitio Web 
- --- | --- 
-- Santa Marta | [https://www.facebook.com/djangosantamarta/](https://www.facebook.com/djangosantamarta/)
+Comunidad | Sitio Web
+ --- | ---
+Django Barranquilla | [http://www.meetup.com/es/Django-Barranquilla/](http://www.meetup.com/es/Django-Barranquilla/)
 
 
-###Pasto
+### Bogotá
 
-Comunidad | Sitio Web 
- --- | --- 
-- Pasto Cali | [http://www.meetup.com/es/Pasto-Python/](http://www.meetup.com/es/Pasto-Python/)
+Comunidad | Sitio Web
+ --- | ---
+Bogotá Python | [http://www.meetup.com/es/pythoncolombia-bogota/](http://www.meetup.com/es/pythoncolombia-bogota/)
+Django Bogotá | [http://www.meetup.com/es/Django-Bogota/](http://www.meetup.com/es/Django-Bogota/)
+
+
+### Cali
+
+Comunidad | Sitio Web
+ --- | ---
+ Django Cali  | [https://www.facebook.com/djangocalico/](https://www.facebook.com/djangocalico/)
+
+
+### Santa Marta
+
+Comunidad | Sitio Web
+ --- | ---
+Santa Marta | [https://www.facebook.com/djangosantamarta/](https://www.facebook.com/djangosantamarta/)
+
+
+### Pasto
+
+Comunidad | Sitio Web
+ --- | ---
+Pasto Cali | [http://www.meetup.com/es/Pasto-Python/](http://www.meetup.com/es/Pasto-Python/)

--- a/comunidades/Costa_Rica.md
+++ b/comunidades/Costa_Rica.md
@@ -1,12 +1,12 @@
 Las comunidades en Costa Rica
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Cuba.md
+++ b/comunidades/Cuba.md
@@ -1,12 +1,12 @@
 Las comunidades en Cuba
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/El_Salvador.md
+++ b/comunidades/El_Salvador.md
@@ -1,12 +1,12 @@
 Las comunidades en El Salvador
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Equador.md
+++ b/comunidades/Equador.md
@@ -1,21 +1,21 @@
-Las comunidades en Equador
+Las comunidades en Ecuador
 
-## Nacional
+## Ecuador
 
-Comunidad | Sitio Web 
- --- | --- 
-- Python Ecuador - sítio | [pythonecuador.org](http://pythonecuador.org/)
-- python-ecuador | [python-ecuador @ google groups](https://groups.google.com/forum/#!forum/python-ecuador)
-- Python Ec | [Python Ec @ Facebook](https://www.facebook.com/groups/python593/)
+Comunidad | Sitio Web
+ --- | ---
+Python Ecuador - sítio | [pythonecuador.org](http://pythonecuador.org/)
+python-ecuador | [python-ecuador @ google groups](https://groups.google.com/forum/#!forum/python-ecuador)
+Python Ec | [Python Ec @ Facebook](https://www.facebook.com/groups/python593/)
 
 ## Quito
 
-Comunidad | Sitio Web 
- --- | --- 
-- pythonquito | [pythonquito @ google groups](https://groups.google.com/forum/#!forum/pythonquito), [pythonquito (conferencia)](http://pythonquito.tk/)
+Comunidad | Sitio Web
+ --- | ---
+pythonquito | [pythonquito @ google groups](https://groups.google.com/forum/#!forum/pythonquito), [pythonquito (conferencia)](http://pythonquito.tk/)
 
 ## Loja
 
-Comunidad | Sitio Web 
- --- | --- 
-- pyloja
+Comunidad | Sitio Web
+ --- | ---
+pyloja

--- a/comunidades/Guatemala.md
+++ b/comunidades/Guatemala.md
@@ -1,12 +1,12 @@
 Las comunidades en Guatemala
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Haiti.md
+++ b/comunidades/Haiti.md
@@ -1,12 +1,12 @@
 Las comunidades en Haiti
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Honduras.md
+++ b/comunidades/Honduras.md
@@ -1,12 +1,12 @@
 Las comunidades en Honduras
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Mexico.md
+++ b/comunidades/Mexico.md
@@ -1,12 +1,12 @@
 Las comunidades en Mexico
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Nicaragua.md
+++ b/comunidades/Nicaragua.md
@@ -1,12 +1,12 @@
 Las comunidades en Nicaragua
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Panama.md
+++ b/comunidades/Panama.md
@@ -1,12 +1,12 @@
 Las comunidades en Panama
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Paraguay.md
+++ b/comunidades/Paraguay.md
@@ -1,12 +1,12 @@
 Las comunidades en Paraguay
 
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Peru.md
+++ b/comunidades/Peru.md
@@ -1,17 +1,12 @@
 Las comunidades en Peru
 
-###Cusco
-
-Comunidad | Sitio Web 
- --- | --- 
-
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Uruguay.md
+++ b/comunidades/Uruguay.md
@@ -1,17 +1,12 @@
 Las comunidades en Uruguay
 
-###Montevideo
-
-Comunidad | Sitio Web 
- --- | --- 
-
-<!-- 
+<!--
 ## Sudeste(ejemplo)
 
 ###Rio de Janeiro(ejemplo)
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
+Comunidad | Sitio Web
+ --- | ---
+PyLadies Rio de Janeiro | [http://rio.pyladies.com/](http://rio.pyladies.com/) 
 
 -->

--- a/comunidades/Venezuela.md
+++ b/comunidades/Venezuela.md
@@ -2,12 +2,11 @@ Las comunidades en Venezuela
 
 ### Venezuela
 
-Comunidad | Sitio Web 
- --- | --- 
-- PyVE | [http://www.python.info.ve/](http://www.python.info.ve/)
-- Lista de Discusión | [https://groups.google.com/forum/#!forum/python-venezuela](https://groups.google.com/forum/#!forum/python-venezuela)
+Comunidad | Sitio Web
+ --- | ---
+PyVE | [http://www.python.info.ve/](http://www.python.info.ve/)
+Lista de Discusión | [https://groups.google.com/forum/#!forum/python-venezuela](https://groups.google.com/forum/#!forum/python-venezuela)
 
-Comunidad | Sitio Web 
- --- | --- 
- - DataScienceVE | [https://t.me/DataScienceVE](https://t.me/DataScienceVE)
- 
+Comunidad | Sitio Web
+ --- | ---
+DataScienceVE | [https://t.me/DataScienceVE](https://t.me/DataScienceVE)


### PR DESCRIPTION
Fiz uma sugestão de como mostrar as comunidades, considerando que elas estavam ambas em tabelas e listas ao mesmo tempo. Achei que tabelas ficariam mais legíveis, já que é mais fácil identificar os títulos. Fiz essa alteração em todos os documentos disponíveis e também nos comentários que continham o modelo de contribuição.

Fiz algumas correções de espaçamento e erros de digitação. Mudei "equador" pra "ecuador" na parte interna da página (talvez seja ideal mudar também o nome da página) e, no Brasil, mudei de "Natal" para "Rio Grande do Norte", seguindo o padrão de classificar por estados.

Fora isso, fiz a adição de algumas comunidades Br (duas em BH e uma seção nacional com o PyLadies Brasil e a Python Brasil).