### PR TITLE
removido link duplicado PyLadies Vale

### DIFF
--- a/comunidades/Brazil.md
+++ b/comunidades/Brazil.md
@@ -32,7 +32,6 @@ PyLadies Campinas | [https://www.facebook.com/pyladiescps](https://www.facebook.
 PyLadies São Carlos | [https://www.facebook.com/PyLadiesSaoCarlos](https://www.facebook.com/PyLadiesSaoCarlos)
 PyLadies Vale | [http://vale.pyladies.com/](http://vale.pyladies.com/)
 Django Girls São José dos Campos | [https://www.facebook.com/djangogirlssjc](https://www.facebook.com/djangogirlssjc)
-Pyladies Vale | [http://vale.pyladies.com/](http://vale.pyladies.com/)
 grupy-rp | [http://grupyrp.github.io/](http://grupyrp.github.io/)
 grupy-sanca | [https://www.facebook.com/grupysanca/](https://www.facebook.com/grupysanca/)
 grupy-sp | [http://www.meetup.com/grupy-sp](http://www.meetup.com/grupy-sp)


### PR DESCRIPTION
Alteração simples, apenas removendo o link duplicado da PyLadies Vale em Brazil.md